### PR TITLE
Add build image for armhf

### DIFF
--- a/docker/Dockerfile.stretch-armhf
+++ b/docker/Dockerfile.stretch-armhf
@@ -1,0 +1,15 @@
+FROM facette/buildenv:stretch-amd64
+
+LABEL maintainer="Development Team <dev@facette.io>"
+
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install --no-install-recommends -t stretch-backports -y \
+        crossbuild-essential-armhf \
+        librrd-dev:armhf && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV CC=arm-linux-gnueabihf-gcc GOARCH=arm
+
+# vim: ft=dockerfile ts=4 sw=4 et


### PR DESCRIPTION
This PR adds a build image for ARM (hard float) environments. I've tested it on my machine and was able to create a Debian package that installed on my Raspberry Pi 3.